### PR TITLE
API Gateway Support

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -61,7 +61,7 @@ functions:
       # API Gateway Events
       # - http:
       #     path: capture
-      #     method: get
+      #     method: post
       # Uncomment the provider api key section above as well as the line
       # below to enable private endpoint support
       #     private: true

--- a/serverless.yml
+++ b/serverless.yml
@@ -20,6 +20,9 @@ provider:
   timeout: 30
   tracing:
     lambda: true
+  # See the API Gateway event below for addiitonal details on api keys
+  # apiKeys:
+  #   - key1
 
 functions:
   captureScreenshot:
@@ -51,12 +54,19 @@ functions:
       IS_MOBILE: "false"
       IS_LANDSCAPE: "false"
     events:
+      # SNS Event
       - sns:
           arn: !Ref chromdaTopic
           topicName: ${self:custom.snsTopic}
+      # API Gateway Events
+      # - http:
+      #     path: capture
+      #     method: get
+      # Uncomment the provider api key section above as well as the line
+      # below to enable private endpoint support
+      #     private: true
       # TODO: add SQS event
       # TODO: add Scheduled event
-      # TODO: add API Gateway event
 
 layers:
   chromda:

--- a/serverless.yml
+++ b/serverless.yml
@@ -20,7 +20,7 @@ provider:
   timeout: 30
   tracing:
     lambda: true
-  # See the API Gateway event below for addiitonal details on api keys
+  # See the API Gateway event below for additional details on api keys
   # apiKeys:
   #   - key1
 

--- a/src/captureScreenshot.js
+++ b/src/captureScreenshot.js
@@ -4,6 +4,7 @@ const { URL } = require("url");
 const chromeLambda = require("chrome-aws-lambda");
 const MrPuppetshot = require("mrpuppetshot");
 const normalizeEvent = require("./helpers/normalizeEvent");
+const normalizeResponse = require("./helpers/normalizeResponse");
 const S3Bucket = require("./helpers/s3bucket");
 
 // Defaults
@@ -131,5 +132,5 @@ exports.handler = async (event, callback) => {
 
   const response = await S3Bucket.upload(buffer, imageType, options.s3key);
 
-  return response;
+  return normalizeResponse(event, response);
 };

--- a/src/helpers/normalizeEvent.js
+++ b/src/helpers/normalizeEvent.js
@@ -18,8 +18,8 @@ const normalizedEvent = event => {
       );
     }
     return JSON.parse(event.Records[0].body);
-  } else if ("httpMethod" in event) {
-    return JSON.parse(event.queryStringParameters.json);
+  } else if ("httpMethod" in event && event.httpMethod === "POST") {
+    return JSON.parse(event.body);
   } else if ("time" in event) {
     return event.detail;
   } else {

--- a/src/helpers/normalizeEvent.js
+++ b/src/helpers/normalizeEvent.js
@@ -19,7 +19,7 @@ const normalizedEvent = event => {
     }
     return JSON.parse(event.Records[0].body);
   } else if ("httpMethod" in event) {
-    return JSON.parse(event.body);
+    return JSON.parse(event.queryStringParameters.json);
   } else if ("time" in event) {
     return event.detail;
   } else {

--- a/src/helpers/normalizeResponse.js
+++ b/src/helpers/normalizeResponse.js
@@ -1,0 +1,26 @@
+/**
+ * @typedef {import('aws-lambda').APIGatewayEvent} APIGatewayEvent
+ * @typedef {import('aws-lambda').ScheduledEvent} ScheduledEvent
+ * @typedef {import('aws-lambda').SNSEvent} SNSEvent
+ * @typedef {import('aws-lambda').SQSEvent} SQSEvent
+ */
+
+/**
+ * @param {APIGatewayEvent|ScheduledEvent|SNSEvent|SQSEvent} event
+ * @param response
+ */
+
+const normalizedResponse = (event, response) => {
+  if ("httpMethod" in event) {
+    return {
+      "statusCode": 200,
+      "body": JSON.stringify(response),
+      "isBase64Encoded": false
+    };
+  }
+  else {
+    return response;
+  }
+};
+
+module.exports = normalizedResponse;


### PR DESCRIPTION
One important note: Most modern tools don’t allow for body payloads on GET requests, so I converted the event normalizer to utilize a “json” request query param. i.e. ?json={“url”:”https://filmfed.com”}

@luisfarzati Please let me know your thoughts on how I handled the commenting inside the Serverless config file.